### PR TITLE
Feat/kat/rejections

### DIFF
--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -77,7 +77,13 @@ export let vendors: Vendor[] = [
     )
 ];
 
-let storefronts: Storefront[] = [
+export let storefronts: Storefront[] = [
+    new Storefront(
+        "UpFF Shakes", // storeName
+        vendors[0], // owner
+        [new MenuItem("Mango graham", 50)], // menu
+        [-12432.2, 142.59] // coords
+    )
 
 ];
 
@@ -127,6 +133,10 @@ export function isPhoneNumberExists(phoneNumber: string) {
 
 export function getStorefrontsFromNames(storeNames: string[]) {
     return storefronts.filter(storefront => storeNames.includes(storefront.getStoreName()));
+}
+
+export function isStorefrontNameExists(storeName: string) {
+    return storefronts.some((storefront) => storefront.getStoreName() === storeName);
 }
 
 export function getVendorStorefronts(vendor: Vendor): Storefront[] {

--- a/src/routes/storefront_form/+page.server.ts
+++ b/src/routes/storefront_form/+page.server.ts
@@ -1,5 +1,5 @@
 import { fail } from '@sveltejs/kit';
-import { getStorefronts, registerStorefront, getVendorStorefronts, vendors, addStorefrontToVendor } from '$lib/server/database';
+import { getStorefronts, registerStorefront, getVendorStorefronts, vendors, addStorefrontToVendor, isStorefrontNameExists } from '$lib/server/database';
 import { coordinates } from '$lib/constants';
 
 // sample vendor as owner
@@ -14,19 +14,13 @@ export const actions = {
         const owner = vendor;
         const menuItemCount = (Array.from(formData.keys()).length - NON_MENU) / 2; // remove non menu items then halve for name and price
         let menu = [];
-        let failure = false; // flag for failure (added in case of future error handling)
-        let data: any = { };
 
         // Start of error checking
-        const storeNameExists = getVendorStorefronts(vendor).some(storefront => storefront.getStoreName() === storeName);
-        if (storeNameExists) {
-            failure = true;
-            data.storeNameExists = true;
+        storeName.trim(); // remove leading and trailing whitespaces
+        const storefrontExists = await isStorefrontNameExists(storeName);
+        if (storefrontExists) {
+            return fail(400, { storeNameExists: true });
         } // check if any of the store name is taken
-
-        if (failure && data != null) {
-            return fail(400, data);
-        }
         // End of error checking
 
         for (let i = 0; i < menuItemCount; i++) {

--- a/src/routes/storefront_management/+page.server.ts
+++ b/src/routes/storefront_management/+page.server.ts
@@ -57,11 +57,13 @@ export const actions = {
         }
 
         // Start of error checking
+
         storeName.trim(); // remove leading and trailing whitespaces
         const storefrontExists = await isStorefrontNameExists(storeName);
-        if (storefrontExists) {
+        if (storefrontExists && renameStorefront) {
             return fail(400, { storeNameExists: true });
         } // check if any of the store name is taken
+
         // End of error checking
         
         const owner = vendor;

--- a/src/routes/storefront_management/+page.server.ts
+++ b/src/routes/storefront_management/+page.server.ts
@@ -1,5 +1,5 @@
 import { fail } from '@sveltejs/kit';
-import { getStorefronts, updateStorefront, getVendorStorefronts, getStorefrontsCoords, vendors, getStorefrontsMenuItems, deleteStorefront} from '$lib/server/database';
+import { getStorefronts, updateStorefront, getVendorStorefronts, getStorefrontsCoords, vendors, getStorefrontsMenuItems, deleteStorefront, isStorefrontNameExists } from '$lib/server/database';
 import { get } from 'https';
 
 // sample vendor as owner
@@ -56,20 +56,12 @@ export const actions = {
             storeName = String(formData.get("storename"));
         }
 
-        // Error checking - check if the store name is taken
-        let failure = false; // flag for failure (added in case of future error handling)
-        let data: any = { };
-
         // Start of error checking
-        const storeNameExists = getVendorStorefronts(vendor).some(storefront => storefront.getStoreName() === storeName);
-        if (storeNameExists) {
-            failure = true;
-            data.storeNameExists = true;
+        storeName.trim(); // remove leading and trailing whitespaces
+        const storefrontExists = await isStorefrontNameExists(storeName);
+        if (storefrontExists) {
+            return fail(400, { storeNameExists: true });
         } // check if any of the store name is taken
-
-        if (failure && data != null) {
-            return fail(400, data);
-        }
         // End of error checking
         
         const owner = vendor;

--- a/src/routes/storefront_management/+page.svelte
+++ b/src/routes/storefront_management/+page.svelte
@@ -135,17 +135,17 @@
 <input type="hidden" name="selectedStorefrontIndex" bind:value={selectedStorefrontIndex} />
 <input type="hidden" name="deleteStorefrontBoolean" bind:value={deleteStorefrontBoolean} />
     <div>
-        <button>Submit</button>
+        <button name="submit">Submit</button>
     </div>
     <div>
-        <button on:click= {handleDeleteStorefront}>Delete Storefront</button>
+        <button on:click= {handleDeleteStorefront} name="delete_storefront">Delete Storefront</button>
     </div>
 </form>
 <div>
-    <button on:click={add_menu_item}>Add menu item (can add more after creation)</button>
+    <button on:click={add_menu_item} name="add_menu">Add menu item (can add more after creation)</button>
 </div>
 <div>
-    <button on:click={remove_menu_item}>Remove menu item</button>
+    <button on:click={remove_menu_item} name="remove_menu">Remove menu item</button>
 </div>
 <div>
     <a href="/storefront_form">Create New Storefront</a>

--- a/tests/test_sprint2.ts
+++ b/tests/test_sprint2.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { a } from 'vitest/dist/suite-xGC-mxBC.js';
 
 test.describe('successful registration of new storefront', () => {
 	test('one menu item', async({ page }) => {
@@ -15,7 +16,7 @@ test.describe('successful registration of new storefront', () => {
 
 	test('two menu items', async({ page }) => {
 		await page.goto('/storefront_form');
-		await page.locator("[name=storename]").fill("Fruit shakes");
+		await page.locator("[name=storename]").fill("Fruit shakes1");
 		await page.locator("[name=store_x]").fill("123.45");
 		await page.locator("[name=store_y]").fill("-876.90");
 		await page.locator("[name=menu_name_0]").fill("Mango graham");
@@ -32,7 +33,7 @@ test.describe('successful registration of new storefront', () => {
 
 	test('add and remove menu item', async({ page }) => {
 		await page.goto('/storefront_form');
-		await page.locator("[name=storename]").fill("Fruit shakes");
+		await page.locator("[name=storename]").fill("Fruit shakes2");
 		await page.locator("[name=store_x]").fill("123.45");
 		await page.locator("[name=store_y]").fill("-876.90");
 		await page.locator("[name=menu_name_0]").fill("Mango graham");
@@ -50,7 +51,7 @@ test.describe('successful registration of new storefront', () => {
 
 	test('three menu items', async({ page }) => {
 		await page.goto('/storefront_form');
-		await page.locator("[name=storename]").fill("Fruit shakes");
+		await page.locator("[name=storename]").fill("Fruit shakes3");
 		await page.locator("[name=store_x]").fill("123.45");
 		await page.locator("[name=store_y]").fill("-876.90");
 		await page.locator("[name=menu_name_0]").fill("Mango graham");
@@ -68,4 +69,92 @@ test.describe('successful registration of new storefront', () => {
 
 		await expect(page.getByText("Congratulations, you registered a new storefront.")).toBeVisible();
 	});
+});
+
+test.describe('unsuccessful registration of new storefront', () => {
+	test('store name already exists (one item)', async({ page }) => {
+		await page.goto('/storefront_form');
+		await page.locator("[name=storename]").fill("Fruit shakes");
+		await page.locator("[name=store_x]").fill("123.45");
+		await page.locator("[name=store_y]").fill("-876.90");
+		await page.locator("[name=menu_name_0]").fill("Mango graham");
+		await page.locator("[name=menu_price_0]").fill("50");
+		await page.locator("[name=submit]").click();
+
+		await expect(page.getByText("Store name is already registered. Please choose a different one.")).toBeVisible();
+	});
+
+	test('store name already exists (two items)', async({ page }) => {
+		await page.goto('/storefront_form');
+		await page.locator("[name=storename]").fill("UpFF Shakes");
+		await page.locator("[name=store_x]").fill("-12432.2");
+		await page.locator("[name=store_y]").fill("142.59");
+		await page.locator("[name=menu_name_0]").fill("Mango graham");
+		await page.locator("[name=menu_price_0]").fill("50");
+
+		await page.locator("[name=add_menu]").click();
+		await page.locator("[name=menu_name_0]").fill("Milo dinosaur");
+		await page.locator("[name=menu_price_0]").fill("150");
+
+		await page.locator("[name=submit]").click();
+
+		await expect(page.getByText("Store name is already registered. Please choose a different one.")).toBeVisible();
+	});
+
+	test('store name already exists (three items)', async({ page }) => {
+		await page.goto('/storefront_form');
+		await page.locator("[name=storename]").fill("UpFF Shakes");
+		await page.locator("[name=store_x]").fill("-12432.2");
+		await page.locator("[name=store_y]").fill("142.59");
+		await page.locator("[name=menu_name_0]").fill("Mango graham");
+		await page.locator("[name=menu_price_0]").fill("50");
+
+		await page.locator("[name=add_menu]").click();
+		await page.locator("[name=menu_name_0]").fill("Milo dinosaur");
+		await page.locator("[name=menu_price_0]").fill("150");
+
+		await page.locator("[name=add_menu]").click();
+		await page.locator("[name=menu_name_0]").fill("Strawberry banana");
+		await page.locator("[name=menu_price_0]").fill("80");
+
+		await page.locator("[name=submit]").click();
+
+		await expect(page.getByText("Store name is already registered. Please choose a different one.")).toBeVisible();
+	});
+});
+
+test.describe('unsuccessful update of storefront', () => {
+	test('store name already exists (no item change)', async({ page }) => {
+		await page.goto('/storefront_management');
+		await page.locator("[name=storename]").selectOption("Fruit shakes");
+		await page.locator("[name=new_storename]").fill("Fruit shakes");
+		await page.locator("[name=submit]").click();
+
+		await expect(page.getByText("Store name is already registered. Please choose a different one.")).toBeVisible();
+	});
+	
+	test('store name already exists (with 1 item change attempt)', async({ page }) => {
+		await page.goto('/storefront_management');
+		await page.locator("[name=storename]").selectOption("Fruit shakes");
+		await page.locator("[name=new_storename]").fill("Fruit shakes");
+		await page.locator("[name=menu_name_0]").fill("Mango graham");
+		await page.locator("[name=menu_price_0]").fill("50");
+		await page.locator("[name=submit]").click();
+
+		await expect(page.getByText("Store name is already registered. Please choose a different one.")).toBeVisible();
+	}); // BOTH changes should NOT push through
+	
+	test('store name already exists (with 2 item change attempt)', async({ page }) => {
+		await page.goto('/storefront_management');
+		await page.locator("[name=storename]").selectOption("Fruit shakes");
+		await page.locator("[name=new_storename]").fill("Fruit shakes");
+		await page.locator("[name=menu_name_0]").fill("Mango graham");
+		await page.locator("[name=menu_price_0]").fill("50");
+		await page.locator("[name=add_menu]").click();
+		await page.locator("[name=menu_name_0]").fill("Milo dinosaur");
+		await page.locator("[name=menu_price_0]").fill("150");
+		await page.locator("[name=submit]").click();
+
+		await expect(page.getByText("Store name is already registered. Please choose a different one.")).toBeVisible();
+	}); // ALL changes should NOT push through
 });


### PR DESCRIPTION
storefront_management page.server.ts: bug fix (storefront name exists error occured even when rename storefront field was empty)


storefront_management page.svelte: added button names

test_sprint2.ts: changed storename for successful SF reg, added new tests for rejections